### PR TITLE
Explicitly require standard library dependencies

### DIFF
--- a/lib/shutterstock/api/subscriptions.rb
+++ b/lib/shutterstock/api/subscriptions.rb
@@ -1,4 +1,6 @@
 require 'shutterstock/api/util'
+require 'ostruct'
+
 module Shutterstock
   module API
     module Subscriptions

--- a/lib/shutterstock/api/util.rb
+++ b/lib/shutterstock/api/util.rb
@@ -1,3 +1,6 @@
+require 'net/http'
+require 'json'
+
 module Shutterstock
   module API
     module Util


### PR DESCRIPTION
The Subscriptions and Util modules contained external dependencies that
were not explicitly required, causing uninitialized constant errors when the gem is
used outside of a framework that has already loaded these dependencies.

This commit adds explicit requires for those missing dependencies.
